### PR TITLE
develop

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.editorconfig
+.env.example
+.eslint*
+.gitignore
+docs
+README.md

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,7 +68,6 @@ jobs:
               touch .env
             fi
             cd $PROD_REPOSITORY_FOLDER
-            git restore .
             git pull origin main
             echo "ADMIN_JWT_SECRET=$PROD_ADMIN_JWT_SECRET" > .env
             echo "API_TOKEN_SALT=$PROD_API_TOKEN_SALT" >> .env
@@ -83,6 +82,7 @@ jobs:
             echo "SMTP_USERNAME=$PROD_SMTP_USERNAME" >> .env
             echo "SMTP_PASSWORD=$PROD_SMTP_PASSWORD" >> .env
             docker compose up -d --build
+            rm .env
       - name: Telegram Notify
         uses: appleboy/telegram-action@master
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.1
+FROM node:18.12.1-alpine
 
 WORKDIR /var/www/celebrations-api
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 
 services:
-  celebrations-api:
+  app:
     build: .
     ports:
       - 1337:1337

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "celebrations-api",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "celebrations-api",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "license": "MIT",
       "dependencies": {
         "@strapi/plugin-documentation": "^4.5.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "celebrations-api",
   "private": true,
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "API for celebrations & holidays",
   "scripts": {
     "develop": "strapi develop",


### PR DESCRIPTION
- npm update --save && npm audit fix
- npm update --save && npm audit fix
- 1.3.12
- Setting NODE_ENV=production on start script
- Removing pm2 for production
- New CD
- Using node:18.12.1-alpine for production image
- Update service name
- Update CD
- Initial .dockerignore
- 1.3.13
